### PR TITLE
Add Dockerfile and deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,63 @@
+name: Deploy
+
+on:
+  # Push to the main branch
+  push:
+    branches:
+      - main
+jobs:
+  # Build and publish the commit to docker
+  docker:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'growthbook/smokescreen' }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Install Depot CLI
+        uses: depot/setup-action@v1
+
+      - name: Prepare build metadata
+        id: metadata
+        run: |
+          # Store current git hash and date in files
+          mkdir -p buildinfo
+          echo "${GITHUB_SHA}" > buildinfo/SHA
+          printf '%(%Y-%m-%dT%H:%M:%SZ)T' > buildinfo/DATE
+          echo "sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+
+      - name: Build, tag, and push image to Docker Hub
+        uses: depot/build-push-action@v1
+        with:
+          push: true
+          context: .
+          project: vmp2ssvj9r
+          tags: |
+            growthbook/smokescreen:latest
+            growthbook/smokescreen:git-${{ steps.metadata.outputs.sha }}
+          platforms: linux/amd64
+
+  # Deploy Smokescreen to AWS ECS
+  prod:
+    runs-on: ubuntu-latest
+    needs: [docker]
+    if: ${{ github.repository == 'growthbook/smokescreen' }}
+    steps:
+      - name: Configure AWS credentials for GrowthBook Cloud
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Deploy docker image to ECS for GrowthBook Cloud API
+        run: aws ecs update-service --cluster prod-smokescreen --service prod-smokescreen --force-new-deployment --region us-east-1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang as builder
+
+WORKDIR /go/src/app
+COPY . .
+
+RUN go build -o smokescreen .
+
+FROM alpine:3.20.1
+
+COPY --from=builder /go/src/app/smokescreen /usr/local/bin/smokescreen
+
+RUN apk add --no-cache gcompat
+
+EXPOSE 4750
+
+CMD ["smokescreen"]


### PR DESCRIPTION
Added a Dockerfile to build smokescreen without any ACLs. By default it should still protect against SSRF attacks.

Deploy will fail until the infrastructure is there, but the docker step should succeed.

Test Plan:
Run `docker build -t smokescreen` .
Run `docker run -p 4750:4750 smokescreen`
Run `curl --proxytunnel -x localhost:4750 https://8ee5-80-187-81-189.ngrok-free.app` . See that it returns with "Received"
Run `curl --proxytunnel -x localhost:4750 http://localhost:8080`. See that it fails with a 407 error.