### PR TITLE
Add a health check endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,7 @@ COPY --from=builder /go/src/app/smokescreen /usr/local/bin/smokescreen
 RUN apk add --no-cache gcompat
 
 EXPOSE 4750
+# For the health check
+EXPOSE 4751 
 
 CMD ["smokescreen"]

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 
@@ -23,7 +24,22 @@ func defaultRoleFromRequest(req *http.Request) (string, error) {
 	return req.TLS.PeerCertificates[0].Subject.CommonName, nil
 }
 
+func healthCheckHandler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "OK")
+}
+
+func startHealthCheckServer() {
+	http.HandleFunc("/healthcheck", healthCheckHandler)
+	// Run the health check server on a different port
+	go func() {
+		log.Fatal(http.ListenAndServe(":4751", nil))
+	}()
+}
+
 func main() {
+	// Register the health check route
+	startHealthCheckServer()
+
 	conf, err := cmd.NewConfiguration(nil, nil)
 	if err != nil {
 		logrus.Fatalf("Could not create configuration: %v", err)

--- a/main.go
+++ b/main.go
@@ -30,14 +30,13 @@ func healthCheckHandler(w http.ResponseWriter, r *http.Request) {
 
 func startHealthCheckServer() {
 	http.HandleFunc("/healthcheck", healthCheckHandler)
-	// Run the health check server on a different port
+	// Run the health check server on a different port than smokescreen proxy
 	go func() {
 		log.Fatal(http.ListenAndServe(":4751", nil))
 	}()
 }
 
 func main() {
-	// Register the health check route
 	startHealthCheckServer()
 
 	conf, err := cmd.NewConfiguration(nil, nil)


### PR DESCRIPTION
This way ECS can make sure that the server is running before migrating traffic to it.